### PR TITLE
Implementing live submission status

### DIFF
--- a/src/main/java/com/shank/offcoder/app/NetworkClient.java
+++ b/src/main/java/com/shank/offcoder/app/NetworkClient.java
@@ -18,6 +18,7 @@ import com.shank.offcoder.Launcher;
 import com.shank.offcoder.cf.Codeforces;
 import com.shank.offcoder.controllers.Controller;
 import javafx.application.Platform;
+import org.json.JSONObject;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -116,6 +117,29 @@ public class NetworkClient {
      *
      * @param URL URL for GET
      */
+    public void JsonGet(String URL, AppThreader.EventCallback<JSONObject> listener) {
+        new Thread(() -> {
+            JSONObject err = new JSONObject();
+            try {
+                Connection.Response response = Jsoup.connect(URL)
+                        .ignoreContentType(true)
+                        .method(Connection.Method.GET)
+                        .execute();
+                if (response.contentType() != null && response.contentType().startsWith("application/json")) {
+                    // Parse the JSON response
+                    Document doc = response.parse();
+                    String jsonText = doc.body().text();
+                    listener.onEvent(new JSONObject(jsonText));
+                } else {
+                    listener.onEvent(err);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+                listener.onEvent(err);
+            }
+        }).start();
+    }
+
     public void ReqGet(String URL, AppThreader.EventCallback<Document> listener) {
         new Thread(() -> {
             Document errDoc = Jsoup.parse("<html> <body> <p id=\"OffError\">Error</p> </body> </html>");

--- a/src/main/resources/com/shank/offcoder/hello-view.fxml
+++ b/src/main/resources/com/shank/offcoder/hello-view.fxml
@@ -111,6 +111,22 @@
                                 style="-fx-background-color: #fff; -fx-border-color: #1a73e8; -fx-border-radius: 8px; -fx-cursor: hand;"
                                 text="Compile &amp; Test" textFill="#1a73e8" AnchorPane.rightAnchor="14.0"
                                 AnchorPane.topAnchor="200.0"/>
+                        <Label id="liveStatus" alignment="CENTER" contentDisplay="CENTER" layoutX="675.0"
+                               layoutY="14.0" prefHeight="25.0" prefWidth="169.0" text="Live Status"
+                               textFill="#ffc000" AnchorPane.topAnchor="280.0"
+                               AnchorPane.rightAnchor="14.0">
+                            <font>
+                                <Font name="System Bold" size="13.0"/>
+                            </font>
+                        </Label>
+                        <Label fx:id="liveCondition" alignment="CENTER" contentDisplay="CENTER" layoutX="675.0"
+                               layoutY="14.0" prefHeight="50.0" prefWidth="169.0" text="No Live Data"
+                               textFill="#ce4bd1" AnchorPane.topAnchor="305.0"
+                               AnchorPane.rightAnchor="14.0">
+                            <font>
+                                <Font name="System Bold" size="13.0"/>
+                            </font>
+                        </Label>
                     </children>
                 </AnchorPane>
                 <BorderPane fx:id="loginPane" prefHeight="600.0" prefWidth="1000.0">
@@ -314,6 +330,14 @@
                                 </ImageView>
                             </children>
                         </AnchorPane>
+                        <Label fx:id="liveConditionHover" alignment="CENTER" contentDisplay="CENTER" layoutX="675.0"
+                               layoutY="14.0" prefHeight="50.0" prefWidth="169.0" text="No Live Data"
+                               textFill="#ce4bd1" AnchorPane.bottomAnchor="200.0"
+                               AnchorPane.rightAnchor="45.0">
+                            <font>
+                                <Font name="System Bold" size="13.0"/>
+                            </font>
+                        </Label>
                         <ProgressIndicator fx:id="problemRetProgress" layoutX="860.0" layoutY="444.0" prefHeight="21.0"
                                            prefWidth="19.0" AnchorPane.bottomAnchor="135.0"
                                            AnchorPane.rightAnchor="121.0"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

I have implemented the feature of showing live submission status. For this, assumption is made that the last 10 submissions are considered as 'live' programs. 

The live status is shown both on selecting a question in the browse menu, or by double clicking on it and opening it.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #6 

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots (if appropriate):
![image](https://github.com/ContriHUB/OffCoder/assets/123102778/fb7bff07-c450-431d-86e1-44bd64786452)
![image](https://github.com/ContriHUB/OffCoder/assets/123102778/81fc5fad-e614-4787-bbc4-810efa064ccd)
![image](https://github.com/ContriHUB/OffCoder/assets/123102778/cad1cf10-9cd3-4c17-9e44-b8bb91941158)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have registered myself at [Contrihub website](https://sac.mnnit.ac.in/contrihub).
- [x] My code follows the code style of this project.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.