### PR TITLE
Add auto-detection of compiler versions

### DIFF
--- a/src/main/java/com/shank/offcoder/cli/CompilerManager.java
+++ b/src/main/java/com/shank/offcoder/cli/CompilerManager.java
@@ -51,26 +51,23 @@ public class CompilerManager {
     private void auditCompilers() {
         mLang.clear();
         auditCompilers(getCommandWithShell(new String[]{"javac --version"}),
-                () -> mLang.add("Java 11.0.6"));
+                mLang::add);
 
         auditCompilers(getCommandWithShell(new String[]{"gcc --version"}),
-                () -> mLang.add("GNU GCC C11 5.1.0"));
+                mLang::add);
 
-        auditCompilers(getCommandWithShell(new String[]{"g++ --version"}), () -> {
-            mLang.add("GNU G++14 6.4.0");
-            mLang.add("GNU G++17 7.3.0");
-        });
+        auditCompilers(getCommandWithShell(new String[]{"g++ --version"}), mLang::add);
 
-        auditCompilers(getCommandWithShell(new String[]{"python2 --version"}),
-                () -> mLang.add("Python 2.7.18"));
+        auditCompilers(getCommandWithShell(new String[]{"py -2 --version"}),
+                mLang::add);
 
-        auditCompilers(getCommandWithShell(new String[]{"python3 --version"}),
-                () -> mLang.add("Python 3.8.10"));
+        auditCompilers(getCommandWithShell(new String[]{"py -3 --version"}),
+                mLang::add);
     }
 
     /**
      * Method to check if compiler of certain language exists.
-     * If exists, call the {@link CompilerCheck#onResult()},
+     * If exists, call the {@link CompilerCheck#onResult(String)},
      * that will add the language selection in {@link #mLang}.
      *
      * @param command       Command for checking compiler
@@ -80,8 +77,9 @@ public class CompilerManager {
         CommandLine.runCommand(new CommandLine.ProcessListener() {
             @Override
             public void onCompleted(int exitCode, String output) {
-                System.out.println("auditCompiler: " + Arrays.toString(command) + "; exitCode = " + exitCode);
-                if (exitCode == 0) compilerCheck.onResult();
+                output = output.trim();
+                System.out.println("auditCompiler: " + Arrays.toString(command) + "; exitCode = " + exitCode + "\n" + output);
+                if (exitCode == 0) compilerCheck.onResult(output);
             }
 
             @Override
@@ -127,6 +125,6 @@ public class CompilerManager {
     public enum OSType {LINUX, WINDOWS}
 
     private interface CompilerCheck {
-        void onResult();
+        void onResult(String data);
     }
 }

--- a/src/main/java/com/shank/offcoder/cli/CompilerManager.java
+++ b/src/main/java/com/shank/offcoder/cli/CompilerManager.java
@@ -79,7 +79,7 @@ public class CompilerManager {
             public void onCompleted(int exitCode, String output) {
                 output = output.trim();
                 System.out.println("auditCompiler: " + Arrays.toString(command) + "; exitCode = " + exitCode + "\n" + output);
-                if (exitCode == 0) compilerCheck.onResult(output);
+                if (exitCode == 0) compilerCheck.onResult(output.split("\n")[0]);
             }
 
             @Override

--- a/src/main/java/com/shank/offcoder/cli/CompilerManager.java
+++ b/src/main/java/com/shank/offcoder/cli/CompilerManager.java
@@ -58,10 +58,10 @@ public class CompilerManager {
 
         auditCompilers(getCommandWithShell(new String[]{"g++ --version"}), mLang::add);
 
-        auditCompilers(getCommandWithShell(new String[]{"py -2 --version"}),
+        auditCompilers(getCommandWithShell(new String[]{"python2 --version"}),
                 mLang::add);
 
-        auditCompilers(getCommandWithShell(new String[]{"py -3 --version"}),
+        auditCompilers(getCommandWithShell(new String[]{"python3 --version"}),
                 mLang::add);
     }
 

--- a/src/main/java/com/shank/offcoder/controllers/Controller.java
+++ b/src/main/java/com/shank/offcoder/controllers/Controller.java
@@ -701,8 +701,7 @@ public class Controller {
     private void queryCodeforcesAPI(String submissionId, AppThreader.EventCallback<String> listener) {
         int contestId = Integer.parseInt(submissionId.substring(0, submissionId.length() - 1));
         String index = Character.toString(submissionId.charAt(submissionId.length() - 1));
-        String handle = AppData.get().getData(AppData.HANDLE_KEY, null);
-        NetworkClient.get().JsonGet(Codeforces.HOST + "/api/user.status?handle=" + handle + "&from=1&count=10", data -> {
+        NetworkClient.get().JsonGet(Codeforces.HOST + "/api/user.status?my=on&from=1&count=10", data -> {
             String def = "No Live Data";
             JSONArray jsonArray = data.getJSONArray("result");
             for (int i = 0; i < jsonArray.length(); i++) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

I have modified the code to extract the compiler version most recently used by the user from the system and display it, instead of the hardcoded versions. While testing, I also faced an issue with the `python3` command on a couple of different systems, so I generalized it to `py -3`. This works completely fine on all systems I have tested on.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1 

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have registered myself at [Contrihub website](https://sac.mnnit.ac.in/contrihub).
- [x] My code follows the code style of this project.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.